### PR TITLE
Added mising fields for directLink without alias

### DIFF
--- a/lib/Ogone/AbstractRequest.php
+++ b/lib/Ogone/AbstractRequest.php
@@ -87,10 +87,10 @@ abstract class AbstractRequest implements Request {
 
     protected $ogoneFields = array(
         'pspid', 'orderid', 'com', 'amount', 'currency', 'language', 'cn', 'email',
-        'ownerzip', 'owneraddress', 'ownercty', 'ownertown', 'ownertelno', 'accepturl',
-        'declineurl', 'exceptionurl', 'cancelurl', 'backurl', 'complus', 'paramplus', 'pm',
-        'brand', 'title', 'bgcolor', 'txtcolor', 'tblbgcolor', 'tbltxtcolor', 'buttonbgcolor',
-        'buttontxtcolor', 'logo', 'fonttype', 'tp', 'paramvar'
+        'cardno', 'cvc', 'ed', 'ownerzip', 'owneraddress', 'ownercty', 'ownertown',
+        'ownertelno', 'accepturl', 'declineurl', 'exceptionurl', 'cancelurl', 'backurl',
+        'complus', 'paramplus', 'pm', 'brand', 'title', 'bgcolor', 'txtcolor', 'tblbgcolor',
+        'tbltxtcolor', 'buttonbgcolor', 'buttontxtcolor', 'logo', 'fonttype', 'tp', 'paramvar'
     );
 
     /** @return string */


### PR DESCRIPTION
For directLink, it's not necessary to set up an alias page. You can send the details yourself by sending the CARDNO, CVC and ED.
