### PR TITLE
allow 40 chars for OwnerTown

### DIFF
--- a/lib/Ogone/AbstractPaymentRequest.php
+++ b/lib/Ogone/AbstractPaymentRequest.php
@@ -155,7 +155,7 @@ abstract class AbstractPaymentRequest extends AbstractRequest
 
     public function setOwnerTown($ownertown)
     {
-        if (strlen($ownertown) > 25) {
+        if (strlen($ownertown) > 40) {
             throw new InvalidArgumentException("Owner town is too long");
         }
         $this->parameters['ownertown'] = $ownertown;


### PR DESCRIPTION
The OwnerTown parameter can be 40 chars long; according to Ogone parameter cookbook