### PR TITLE
Require the minimum php version in the composer.json file.

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -3,6 +3,9 @@
     "autoload": {
         "psr-0": { "Ogone": "lib/" }
     },
+    "require": {
+        "php": ">=5.3"
+    },
     "require-dev" : {
         "phpunit/phpunit": "3.7.*",
         "guzzle/guzzle": "3.7.*",


### PR DESCRIPTION
The minimum php version (5.3) is stated in the readme, but not enforced in the composer.json file.