### PR TITLE
Make sure Ecommerce Alias is not too long

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,10 @@
 {
     "name": "marlon-be/marlon-ogone",
     "autoload": {
-        "psr-0": { "Ogone": "lib/" }
+        "psr-4": {
+            "Ogone\\": "lib/Ogone/",
+            "Ogone\\Tests\\": "tests/Ogone/Tests/"
+        }
     },
     "require": {
         "php": ">=5.3"

--- a/lib/Ogone/Ecommerce/Alias.php
+++ b/lib/Ogone/Ecommerce/Alias.php
@@ -20,6 +20,10 @@ class Alias
 
     public function __construct($alias, $aliasOperation = self::OPERATION_BY_MERCHANT, $aliasUsage = null)
     {
+        if (strlen($alias) > 50) {
+            throw new InvalidArgumentException("Alias is too long");
+        }
+
         if (preg_match('/[^a-zA-Z0-9_-]/', $alias)) {
             throw new InvalidArgumentException("Alias cannot contain special characters");
         }

--- a/tests/Ogone/Tests/Ecommerce/AliasTest.php
+++ b/tests/Ogone/Tests/Ecommerce/AliasTest.php
@@ -32,6 +32,15 @@ class AliasTest extends TestCase
      * @test
      * @expectedException \InvalidArgumentException
      */
+    public function AliasIsMax50Characters()
+    {
+        new Alias(str_repeat('X', 51));
+    }
+
+    /**
+     * @test
+     * @expectedException \InvalidArgumentException
+     */
     public function AliasIsAlphaNumeric()
     {
         new Alias('some alias with spaces, dots (.), etc');

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -21,9 +21,6 @@ use Ogone\DirectLink\DirectLinkMaintenanceRequest;
 use Ogone\DirectLink\DirectLinkPaymentRequest;
 use Ogone\DirectLink\DirectLinkQueryRequest;
 
-require_once 'PHPUnit/Framework/TestCase.php';
-require_once __DIR__.'/Ogone/Tests/ShaComposer/FakeShaComposer.php';
-
 abstract class TestCase extends PHPUnit_Framework_TestCase
 {
     /** @return EcommercePaymentRequest*/


### PR DESCRIPTION
Make sure Ecommerce Alias is not too long. Just like it is done for DirectLink Alias already.

Also, fix an autoloading issue that made the build fail on Travis CI.