### PR TITLE
Do not validate URI when setting template URL

### DIFF
--- a/lib/Ogone/AbstractPaymentRequest.php
+++ b/lib/Ogone/AbstractPaymentRequest.php
@@ -300,7 +300,6 @@ abstract class AbstractPaymentRequest extends AbstractRequest
 
     public function setTp($tp)
     {
-        $this->validateUri($tp);
         $this->parameters['tp'] = $tp;
     }
 


### PR DESCRIPTION
When using the Ingenico/Ogone hosting in your account you need to set the template as a relative URL which does not validate at the moment. How about removing validation altogether as Ogone does not load invalid Template URLs?
