### PR TITLE
Give up a correct hashAlgorithm when not given one

### DIFF
--- a/lib/Ogone/ShaComposer/LegacyShaComposer.php
+++ b/lib/Ogone/ShaComposer/LegacyShaComposer.php
@@ -37,7 +37,7 @@ class LegacyShaComposer implements ShaComposer
     public function __construct(Passphrase $passphrase, HashAlgorithm $hashAlgorithm = null)
     {
         $this->passphrase = $passphrase;
-        $this->hashAlgorithm = $hashAlgorithm ?: new HashAlgorithm($hashAlgorithm::HASH_SHA1);
+        $this->hashAlgorithm = $hashAlgorithm ?: new HashAlgorithm(HashAlgorithm::HASH_SHA1);
     }
 
     /**

--- a/tests/Ogone/Tests/ShaComposer/LegacyShaComposerTest.php
+++ b/tests/Ogone/Tests/ShaComposer/LegacyShaComposerTest.php
@@ -24,6 +24,15 @@ class LegacyShaComposerTest extends \PHPUnit_Framework_TestCase
     const SHA512STRING = '8552200DD108CB5633A27D6D0A1FAB54378CB2385BFCEB27487992D16F5A7565E5DD4D38C0F2DB294213CD02E434F311021749E6DAB187357F786E3F199781CA';
 
     /** @test */
+    public function defaultParameters()
+    {
+        $aRequest = $this->provideRequest();
+        $composer = new LegacyShaComposer(new Passphrase(self::PASSPHRASE));
+        $shaString = $composer->compose($aRequest);
+        $this->assertEquals(self::SHA1STRING, $shaString);
+    }
+
+    /** @test */
     public function Sha1StringCanBeComposed()
     {
         $aRequest = $this->provideRequest();


### PR DESCRIPTION
Calling up LegacyShaComposer with default values as stated in the main documentation produces a fatal error because no object exists.

This object should reference the class instead of a variable, so this fixes that.

Unit tests for this new scenario are provided as well