### PR TITLE
Adding some more payment statusses

### DIFF
--- a/lib/Ogone/AbstractPaymentResponse.php
+++ b/lib/Ogone/AbstractPaymentResponse.php
@@ -40,6 +40,10 @@ abstract class AbstractPaymentResponse extends AbstractResponse implements Payme
 
     public function isSuccessful()
     {
-        return in_array($this->getParam('STATUS'), array(PaymentResponse::STATUS_AUTHORISED, PaymentResponse::STATUS_PAYMENT_REQUESTED));
+        return in_array($this->getParam('STATUS'), array(
+            PaymentResponse::STATUS_AUTHORISED,
+            PaymentResponse::STATUS_PAYMENT_REQUESTED,
+            PaymentResponse::STATUS_PAYMENT_BY_MERCHANT
+        ));
     }
 }

--- a/lib/Ogone/PaymentResponse.php
+++ b/lib/Ogone/PaymentResponse.php
@@ -56,4 +56,65 @@ interface PaymentResponse extends Response
      * @var int
      */
     const STATUS_PAYMENT_REFUSED = 93;
+
+    /**
+     * The authorisation deletion will be processed offline.
+     *
+     * @var int
+     */
+    const STATUS_PENDING_AUTHORISATION_CANCELLATION = 61;
+
+    /**
+     * A technical problem arose during the authorisation deletion process, giving an unpredictable result.
+     *
+     * The merchant can contact the acquirer helpdesk to establish the precise status of the payment or wait until we
+     * have updated the status in our system.
+     *
+     * Usually NCERROR will contain a 200x error
+     *
+     * @var int
+     */
+    const STATUS_UNKNOWN_AUTHORISATION_CANCELLATION = 62;
+
+    /**
+     * A technical problem arose. Usually NCERROR will contain a 300x error
+     *
+     * @var int
+     */
+    const STATUS_DENIED_AUTHORISATION_CANCELLATION = 63;
+
+    /**
+     * Waiting for payment cancellation/deletion
+     *
+     * @var int
+     */
+    const STATUS_PENDING_PAYMENT_CANCELLATION = 71;
+
+    /**
+     * @var int
+     */
+    const STATUS_UNKNOWN_PAYMENT_CANCELLATION = 72;
+
+    /**
+     * @var int
+     */
+    const STATUS_DENIED_PAYMENT_CANCELLATION = 73;
+
+    /**
+     * @var int
+     */
+    const STATUS_PAYMENT_CANCELLED = 74;
+
+    /**
+     * Waiting for refund of the payment
+     *
+     * @var int
+     */
+    const STATUS_PENDING_REFUND = 81;
+
+    /**
+     * When the payment is set to paid manually
+     * @var int
+     */
+    const STATUS_PAYMENT_BY_MERCHANT = 95;
 }


### PR DESCRIPTION
Not quite complete yet, but at least the most common ones are now filled
in.

The complete list of statusses is as follows:
```
0	Invalid or incomplete
1	Cancelled by customer
2	Authorisation declined
4	Order stored
40	Stored waiting external result
41	Waiting for client payment
46	Waiting authentication
5	Authorised
50	Authorized waiting external result
51	Authorisation waiting
52	Authorisation not known
55	Standby
56	OK with scheduled payments
57	Not OK with scheduled payments
59	Authoris. to be requested manually
6	Authorised and cancelled
61	Author. deletion waiting
62	Author. deletion uncertain
63	Author. deletion refused
64	Authorised and cancelled
7	Payment deleted
71	Payment deletion pending
72	Payment deletion uncertain
73	Payment deletion refused
74	Payment deleted
75	Deletion handled by merchant
8	Refund
81	Refund pending
82	Refund uncertain
83	Refund refused
84	Refund
85	Refund handled by merchant
9	Payment requested
91	Payment processing
92	Payment uncertain
93	Payment refused
94	Refund declined by the acquirer
95	Payment handled by merchant
96	Refund reversed
99	Being processed
```
The source can be found when logging into OGONE, tab Support, User
Guides, List of the payment statuses and error codes