### PR TITLE
Allow a custom text for the submit button

### DIFF
--- a/lib/Ogone/FormGenerator/SimpleFormGenerator.php
+++ b/lib/Ogone/FormGenerator/SimpleFormGenerator.php
@@ -31,9 +31,10 @@ class SimpleFormGenerator implements FormGenerator
      * @param EcommercePaymentRequest $ecommercePaymentRequest
      * @param string $formName
      * @param bool $showSubmitButton
+     * @param string $textSubmitButton The text displayed on the submit button of the form. Defaults to "Submit"
      * @return string HTML
      */
-    public function render(EcommercePaymentRequest $ecommercePaymentRequest, $formName = 'ogone', $showSubmitButton = true)
+    public function render(EcommercePaymentRequest $ecommercePaymentRequest, $formName = 'ogone', $showSubmitButton = true, $textSubmitButton = 'Submit')
     {
         $formName = null !== $this->formName?$this->formName:$formName;
         $showSubmitButton = null !== $this->showSubmitButton?$this->showSubmitButton:$showSubmitButton;

--- a/lib/Ogone/FormGenerator/template/simpleForm.php
+++ b/lib/Ogone/FormGenerator/template/simpleForm.php
@@ -7,6 +7,6 @@
 <input type="hidden" name="<?php echo Ogone\PaymentRequest::SHASIGN_FIELD ?>" value="<?php echo $ecommercePaymentRequest->getShaSign()?>" />
 
 <?php if ($showSubmitButton) : ?>
-    <input name="ogonesubmit" type="submit" value="Submit" id="ogonesubmit" />
+    <input name="ogonesubmit" type="submit" value="<?php echo $textSubmitButton ?>" id="ogonesubmit" />
 <?php endif ?>
 </form>


### PR DESCRIPTION
The displayed text is always "Submit". While this is a standard practice, it certainly isn't that obvious for non-english speakers. This commit enables us to pass on a custom text to the form.