### PR TITLE
Raise an invalidArgumentException on missing AMOUNT

### DIFF
--- a/lib/Ogone/AbstractPaymentResponse.php
+++ b/lib/Ogone/AbstractPaymentResponse.php
@@ -10,6 +10,8 @@
 
 namespace Ogone;
 
+use InvalidArgumentException;
+
 abstract class AbstractPaymentResponse extends AbstractResponse implements PaymentResponse
 {
     /**
@@ -17,6 +19,10 @@ abstract class AbstractPaymentResponse extends AbstractResponse implements Payme
      */
     public function getAmount()
     {
+        if (!isset($this->parameters['AMOUNT'])) {
+            throw new InvalidArgumentException('Parameter AMOUNT does not exist');
+        }
+
         $value = trim($this->parameters['AMOUNT']);
 
         $withoutDecimals = '#^\d*$#';


### PR DESCRIPTION
When, for example, a merch ref does not exist, OGONE will give back an error. 
This error won't (obviously) contain an amount, because there isn't any. However, the class itself will have the getAmount() function implemented, which prevents the previous check (see https://github.com/marlon-be/marlon-ogone/blob/master/lib/Ogone/AbstractResponse.php#L85) from raising an exception. 

This patch will do just that: raise an InvalidArgumentException when the AMOUNT parameter isn't set.