### PR TITLE
Update mininal string length check for UserId

### DIFF
--- a/lib/Ogone/DirectLink/DirectLinkPaymentRequest.php
+++ b/lib/Ogone/DirectLink/DirectLinkPaymentRequest.php
@@ -40,7 +40,7 @@ class DirectLinkPaymentRequest extends AbstractPaymentRequest
 
     public function setUserId($userid)
     {
-        if (strlen($userid) < 8) {
+        if (strlen($userid) < 2) {
             throw new InvalidArgumentException("User ID is too short");
         }
         $this->parameters['userid'] = $userid;

--- a/tests/Ogone/Tests/DirectLink/DirectLinkPaymentRequestTest.php
+++ b/tests/Ogone/Tests/DirectLink/DirectLinkPaymentRequestTest.php
@@ -107,7 +107,7 @@ class DirectLinkPaymentRequestTest extends \PHPUnit_Framework_TestCase
     {
         return array(
             array('setPswd', '12'),
-            array('setUserid', '12'),
+            array('setUserid', '1'),
         );
     }
 


### PR DESCRIPTION
Reduce minimal string length for UserId to 2 in DirectLinkPaymentRequest

See: https://payment-services.ingenico.com/int/en/ogone/support/guides/integration%20guides/directlink/request-a-new%20order#requestparameters