### PR TITLE
Add license to composer.json (for Packagist)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -6,6 +6,7 @@
             "Ogone\\Tests\\": "tests/Ogone/Tests/"
         }
     },
+    "license": "MIT",
     "require": {
         "php": ">=5.3"
     },


### PR DESCRIPTION
Currently Packagist is showing an "Unknown license" for the package (see https://packagist.org/packages/marlon-be/marlon-ogone).

This PR should fix that minor issue.