### PR TITLE
Camelcased properties not not accessible

### DIFF
--- a/lib/Ogone/Ecommerce/EcommercePaymentRequest.php
+++ b/lib/Ogone/Ecommerce/EcommercePaymentRequest.php
@@ -40,7 +40,7 @@ class EcommercePaymentRequest extends AbstractPaymentRequest
 
     public function setAlias(Alias $alias)
     {
-        $this->parameters['aliasOperation'] = $alias->getAliasOperation();
+        $this->parameters['aliasoperation'] = $alias->getAliasOperation();
         $this->parameters['aliasusage'] = $alias->getAliasUsage();
         $this->parameters['alias'] = $alias->getAlias();
     }


### PR DESCRIPTION
In the __call method located in the AbstractRequest.php file on line 226-230 the given method name will be lowercased so it is not possible to access a camelcased array index.